### PR TITLE
Objects being copied when building with instances

### DIFF
--- a/src/Address.js
+++ b/src/Address.js
@@ -1,4 +1,5 @@
-var ExtensibleData = require('./ExtensibleData');
+var ExtensibleData = require('./ExtensibleData'),
+    utils = require('./utils');
 
 /**
  * An address.
@@ -11,6 +12,11 @@ var Address = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof Address)){
     return new Address(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Address.isInstance(json)){
+    return json;
   }
   
   ExtensibleData.call(this, json);
@@ -31,6 +37,18 @@ var Address = function(json){
 };
 
 Address.prototype = Object.create(ExtensibleData.prototype);
+
+Address._gedxClass = Address.prototype._gedxClass = 'GedcomX.Address';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Address.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the complete address value

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -3,7 +3,8 @@ var ExtensibleData = require('./ExtensibleData'),
     OnlineAccount = require('./OnlineAccount'),
     Address = require('./Address'),
     Identifiers = require('./Identifiers'),
-    TextValue = require('./TextValue');
+    TextValue = require('./TextValue'),
+    utils = require('./utils');
 
 /**
  * Someone or something that curates genealogical data, such as a genealogical 
@@ -17,6 +18,11 @@ var Agent = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof Agent)){
     return new Agent(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Agent.isInstance(json)){
+    return json;
   }
   
   ExtensibleData.call(this, json);
@@ -35,6 +41,18 @@ var Agent = function(json){
 };
 
 Agent.prototype = Object.create(ExtensibleData.prototype);
+
+Agent._gedxClass = Agent.prototype._gedxClass = 'GedcomX.Agent';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Agent.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the identifiers

--- a/src/Attribution.js
+++ b/src/Attribution.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    ResourceReference = require('./ResourceReference');
+    ResourceReference = require('./ResourceReference'),
+    utils = require('./utils');
 
 /**
  * Define who is contributing information, when they contributed it, 
@@ -15,6 +16,11 @@ var Attribution = function(json){
     return new Attribution(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Attribution.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -27,6 +33,18 @@ var Attribution = function(json){
 };
 
 Attribution.prototype = Object.create(ExtensibleData.prototype);
+
+Attribution._gedxClass = Attribution.prototype._gedxClass = 'GedcomX.Attribution';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Attribution.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the change message.

--- a/src/Conclusion.js
+++ b/src/Conclusion.js
@@ -2,7 +2,8 @@ var ExtensibleData = require('./ExtensibleData'),
     Attribution = require('./Attribution'),
     ResourceReference = require('./ResourceReference'),
     Note = require('./Note'),
-    SourceReference = require('./SourceReference');
+    SourceReference = require('./SourceReference'),
+    utils = require('./utils');
 
 /**
  * An abstract concept for a basic genealogical data item.
@@ -15,6 +16,11 @@ var Conclusion = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof Conclusion)){
     return new Conclusion(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Conclusion.isInstance(json)){
+    return json;
   }
   
   ExtensibleData.call(this, json);
@@ -30,6 +36,18 @@ var Conclusion = function(json){
 };
 
 Conclusion.prototype = Object.create(ExtensibleData.prototype);
+
+Conclusion._gedxClass = Conclusion.prototype._gedxClass = 'GedcomX.Conclusion';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Conclusion.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the attribution.

--- a/src/Coverage.js
+++ b/src/Coverage.js
@@ -1,6 +1,7 @@
 var ExtensibleData = require('./ExtensibleData'),
     GDate = require('./Date'),
-    PlaceReference = require('./PlaceReference');
+    PlaceReference = require('./PlaceReference'),
+    utils = require('./utils');
 
 /**
  * A description of the spatial and temporal coverage of a resource.
@@ -15,6 +16,11 @@ var Coverage = function(json){
     return new Coverage(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Coverage.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -24,6 +30,18 @@ var Coverage = function(json){
 };
 
 Coverage.prototype = Object.create(ExtensibleData.prototype);
+
+Coverage._gedxClass = Coverage.prototype._gedxClass = 'GedcomX.Coverage';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Coverage.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the spatial coverage

--- a/src/Date.js
+++ b/src/Date.js
@@ -1,4 +1,5 @@
-var ExtensibleData = require('./ExtensibleData');
+var ExtensibleData = require('./ExtensibleData'),
+    utils = require('./utils');
 
 /**
  * A date.
@@ -14,6 +15,11 @@ var GDate = function(json){
     return new GDate(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(GDate.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -23,6 +29,18 @@ var GDate = function(json){
 };
 
 GDate.prototype = Object.create(ExtensibleData.prototype);
+
+GDate._gedxClass = GDate.prototype._gedxClass = 'GedcomX.Date';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+GDate.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the original date value

--- a/src/Document.js
+++ b/src/Document.js
@@ -1,5 +1,6 @@
 var Conclusion = require('./Conclusion'),
-    Attribution = require('./Attribution');
+    Attribution = require('./Attribution'),
+    utils = require('./utils');
 
 /**
  * A textual document
@@ -14,6 +15,11 @@ var Document = function(json){
     return new Document(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Document.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -26,6 +32,18 @@ var Document = function(json){
 };
 
 Document.prototype = Object.create(Conclusion.prototype);
+
+Document._gedxClass = Document.prototype._gedxClass = 'GedcomX.Document';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Document.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the type

--- a/src/Event.js
+++ b/src/Event.js
@@ -1,7 +1,8 @@
 var Subject = require('./Subject'),
     GDate = require('./Date'),
     PlaceReference = require('./PlaceReference'),
-    EventRole = require('./EventRole');
+    EventRole = require('./EventRole'),
+    utils = require('./utils');
 
 /**
  * An event.
@@ -16,6 +17,11 @@ var Event = function(json){
     return new Event(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Event.isInstance(json)){
+    return json;
+  }
+  
   Subject.call(this, json);
   
   if(json){
@@ -27,6 +33,18 @@ var Event = function(json){
 };
 
 Event.prototype = Object.create(Subject.prototype);
+
+Event._gedxClass = Event.prototype._gedxClass = 'GedcomX.Event';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Event.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the type

--- a/src/EventRole.js
+++ b/src/EventRole.js
@@ -1,5 +1,6 @@
 var Conclusion = require('./Conclusion'),
-    ResourceReference = require('./ResourceReference');
+    ResourceReference = require('./ResourceReference'),
+    utils = require('./utils');
 
 /**
  * A role that a specific person plays in an event.
@@ -14,6 +15,11 @@ var EventRole = function(json){
     return new EventRole(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Conclusion.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -24,6 +30,18 @@ var EventRole = function(json){
 };
 
 EventRole.prototype = Object.create(Conclusion.prototype);
+
+Conclusion._gedxClass = Conclusion.prototype._gedxClass = 'GedcomX.Conclusion';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Conclusion.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the person

--- a/src/EvidenceReference.js
+++ b/src/EvidenceReference.js
@@ -1,5 +1,6 @@
 var ResourceReference = require('./ResourceReference'),
-    Attribution = require('./Attribution');
+    Attribution = require('./Attribution'),
+    utils = require('./utils');
 
 /**
  * A generic reference to a resource.
@@ -14,6 +15,11 @@ var EvidenceReference = function(json){
     return new EvidenceReference(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(ResourceReference.isInstance(json)){
+    return json;
+  }
+  
   ResourceReference.call(this, json);
   
   if(json){
@@ -22,6 +28,18 @@ var EvidenceReference = function(json){
 };
 
 EvidenceReference.prototype = Object.create(ResourceReference.prototype);
+
+ResourceReference._gedxClass = ResourceReference.prototype._gedxClass = 'GedcomX.ResourceReference';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+ResourceReference.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the attribution.

--- a/src/ExtensibleData.js
+++ b/src/ExtensibleData.js
@@ -1,3 +1,5 @@
+var utils = require('./utils');
+
 /**
  * A set of data that supports extension elements.
  * 
@@ -11,9 +13,26 @@ var ExtensibleData = function(json){
     return new ExtensibleData(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(ExtensibleData.isInstance(json)){
+    return json;
+  }
+  
   if(json){
     this.setId(json.id);
   }
+};
+
+ExtensibleData._gedxClass = ExtensibleData.prototype._gedxClass = 'GedcomX.ExtensibleData';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+ExtensibleData.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
 };
 
 /**

--- a/src/Fact.js
+++ b/src/Fact.js
@@ -1,7 +1,8 @@
 var Conclusion = require('./Conclusion'),
     PlaceReference = require('./PlaceReference'),
     GDate = require('./Date'),
-    Qualifier = require('./Qualifier');
+    Qualifier = require('./Qualifier'),
+    utils = require('./utils');
 
 /**
  * A fact for a person or relationship.
@@ -16,6 +17,11 @@ var Fact = function(json){
     return new Fact(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Fact.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -28,6 +34,18 @@ var Fact = function(json){
 };
 
 Fact.prototype = Object.create(Conclusion.prototype);
+
+Fact._gedxClass = Fact.prototype._gedxClass = 'GedcomX.Fact';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Fact.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the fact type

--- a/src/GedcomX.js
+++ b/src/GedcomX.js
@@ -6,7 +6,8 @@ var ExtensibleData = require('./ExtensibleData'),
     Event = require('./Event'),
     Document = require('./Document'),
     PlaceDescription = require('./PlaceDescription'),
-    Attribution = require('./Attribution');
+    Attribution = require('./Attribution'),
+    utils = require('./utils');
 
 /**
  * A GEDCOM X document.
@@ -19,6 +20,17 @@ var GedcomX = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof GedcomX)){
     return new GedcomX(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  /*
+  if(utils.instanceOf(json, this._gedxClass)){
+    return json;
+  }
+  */
+  
+  if(GedcomX.isInstance(json)){
+    return json;
   }
   
   ExtensibleData.call(this, json);
@@ -36,6 +48,18 @@ var GedcomX = function(json){
 };
 
 GedcomX.prototype = Object.create(ExtensibleData.prototype);
+
+GedcomX._gedxClass = GedcomX.prototype._gedxClass = 'GedcomX';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+GedcomX.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the persons

--- a/src/Gender.js
+++ b/src/Gender.js
@@ -1,4 +1,5 @@
-var Conclusion = require('./Conclusion');
+var Conclusion = require('./Conclusion'),
+    utils = require('./utils');
 
 /**
  * A gender conclusion.
@@ -13,6 +14,11 @@ var Gender = function(json){
     return new Gender(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Gender.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -21,6 +27,18 @@ var Gender = function(json){
 };
 
 Gender.prototype = Object.create(Conclusion.prototype);
+
+Gender._gedxClass = Gender.prototype._gedxClass = 'GedcomX.Gender';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Gender.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the gender type

--- a/src/Identifiers.js
+++ b/src/Identifiers.js
@@ -1,3 +1,5 @@
+var utils = require('./utils');
+
 /**
  * Manage the set of identifers for an object.
  * 
@@ -11,6 +13,11 @@ var Identifiers = function(json){
     return new Identifiers(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Identifiers.isInstance(json)){
+    return json;
+  }
+  
   this.identifiers = {};
   
   if(json){
@@ -21,6 +28,19 @@ var Identifiers = function(json){
     }
   }
 };
+
+Identifiers._gedxClass = Identifiers.prototype._gedxClass = 'GedcomX.Identifiers';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Identifiers.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
+
 
 /**
  * Export the object as JSON

--- a/src/Name.js
+++ b/src/Name.js
@@ -1,6 +1,7 @@
 var Conclusion = require('./Conclusion'),
     NameForm = require('./NameForm'),
-    GDate = require('./Date');
+    GDate = require('./Date'),
+    utils = require('./utils');
 
 /**
  * A name.
@@ -15,6 +16,11 @@ var Name = function(json){
     return new Name(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Name.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -25,6 +31,18 @@ var Name = function(json){
 };
 
 Name.prototype = Object.create(Conclusion.prototype);
+
+Name._gedxClass = Name.prototype._gedxClass = 'GedcomX.Name';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Name.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the name type

--- a/src/NameForm.js
+++ b/src/NameForm.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    NamePart = require('./NamePart');
+    NamePart = require('./NamePart'),
+    utils = require('./utils');
 
 /**
  * A form of a name.
@@ -14,6 +15,11 @@ var NameForm = function(json){
     return new NameForm(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(NameForm.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -24,6 +30,18 @@ var NameForm = function(json){
 };
 
 NameForm.prototype = Object.create(ExtensibleData.prototype);
+
+NameForm._gedxClass = NameForm.prototype._gedxClass = 'GedcomX.NameForm';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+NameForm.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the lang tag

--- a/src/NamePart.js
+++ b/src/NamePart.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    Qualifier = require('./Qualifier');
+    Qualifier = require('./Qualifier'),
+    utils = require('./utils');
 
 /**
  * A part of a name.
@@ -14,6 +15,11 @@ var NamePart = function(json){
     return new NamePart(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(NamePart.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -24,6 +30,18 @@ var NamePart = function(json){
 };
 
 NamePart.prototype = Object.create(ExtensibleData.prototype);
+
+NamePart._gedxClass = NamePart.prototype._gedxClass = 'GedcomX.NamePart';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+NamePart.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the type

--- a/src/Note.js
+++ b/src/Note.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    Attribution = require('./Attribution');
+    Attribution = require('./Attribution'),
+    utils = require('./utils');
 
 /**
  * A note about a resource.
@@ -14,6 +15,11 @@ var Note = function(json){
     return new Note(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Note.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -25,6 +31,18 @@ var Note = function(json){
 };
 
 Note.prototype = Object.create(ExtensibleData.prototype);
+
+Note._gedxClass = Note.prototype._gedxClass = 'GedcomX.Note';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Note.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the language identifier.

--- a/src/OnlineAccount.js
+++ b/src/OnlineAccount.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    ResourceReference = require('./ResourceReference');
+    ResourceReference = require('./ResourceReference'),
+    utils = require('./utils');
 
 /**
  * An online account for a web application.
@@ -14,6 +15,11 @@ var OnlineAccount = function(json){
     return new OnlineAccount(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(OnlineAccount.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -23,6 +29,18 @@ var OnlineAccount = function(json){
 };
 
 OnlineAccount.prototype = Object.create(ExtensibleData.prototype);
+
+OnlineAccount._gedxClass = OnlineAccount.prototype._gedxClass = 'GedcomX.OnlineAccount';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+OnlineAccount.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the service home page

--- a/src/Person.js
+++ b/src/Person.js
@@ -1,7 +1,8 @@
 var Subject = require('./Subject'),
     Gender = require('./Gender'),
     Name = require('./Name'),
-    Fact = require('./Fact');
+    Fact = require('./Fact'),
+    utils = require('./utils');
     
 /**
  * A person.
@@ -16,6 +17,11 @@ var Person = function(json){
     return new Person(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Person.isInstance(json)){
+    return json;
+  }
+  
   Subject.call(this, json);
   
   if(json){
@@ -27,6 +33,18 @@ var Person = function(json){
 };
 
 Person.prototype = Object.create(Subject.prototype);
+
+Person._gedxClass = Person.prototype._gedxClass = 'GedcomX.Person';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Person.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Check whether the person is marked as private

--- a/src/PlaceDescription.js
+++ b/src/PlaceDescription.js
@@ -1,7 +1,8 @@
 var Subject = require('./Subject'),
     ResourceReference = require('./ResourceReference'),
     TextValue = require('./TextValue'),
-    GDate = require('./Date');
+    GDate = require('./Date'),
+    utils = require('./utils');
 
 /**
  * A description of a place
@@ -14,6 +15,11 @@ var PlaceDescription = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof PlaceDescription)){
     return new PlaceDescription(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(PlaceDescription.isInstance(json)){
+    return json;
   }
   
   Subject.call(this, json);
@@ -31,6 +37,18 @@ var PlaceDescription = function(json){
 };
 
 PlaceDescription.prototype = Object.create(Subject.prototype);
+
+PlaceDescription._gedxClass = PlaceDescription.prototype._gedxClass = 'GedcomX.PlaceDescription';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+PlaceDescription.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the type

--- a/src/PlaceReference.js
+++ b/src/PlaceReference.js
@@ -1,4 +1,5 @@
-var ExtensibleData = require('./ExtensibleData');
+var ExtensibleData = require('./ExtensibleData'),
+    utils = require('./utils');
 
 /**
  * A reference to a {@link PlaceDescription}.
@@ -13,6 +14,11 @@ var PlaceReference = function(json){
     return new PlaceReference(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(ExtensibleData.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -22,6 +28,18 @@ var PlaceReference = function(json){
 };
 
 PlaceReference.prototype = Object.create(ExtensibleData.prototype);
+
+ExtensibleData._gedxClass = ExtensibleData.prototype._gedxClass = 'GedcomX.ExtensibleData';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+ExtensibleData.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the original text

--- a/src/Qualifier.js
+++ b/src/Qualifier.js
@@ -1,3 +1,5 @@
+var utils = require('./utils');
+
 /**
  * Qualifiers are used to supply additional details about a piece of data.
  * 
@@ -11,10 +13,27 @@ var Qualifier = function(json){
     return new Qualifier(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Qualifier.isInstance(json)){
+    return json;
+  }
+  
   if(json){
     this.setName(json.name);
     this.setValue(json.value);
   }
+};
+
+Qualifier._gedxClass = Qualifier.prototype._gedxClass = 'GedcomX.Qualifier';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Qualifier.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
 };
 
 /**

--- a/src/Relationship.js
+++ b/src/Relationship.js
@@ -1,6 +1,7 @@
 var Subject = require('./Subject'),
     Fact = require('./Fact'),
-    ResourceReference = require('./ResourceReference');
+    ResourceReference = require('./ResourceReference'),
+    utils = require('./utils');
     
 /**
  * A relationship.
@@ -15,6 +16,11 @@ var Relationship = function(json){
     return new Relationship(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Relationship.isInstance(json)){
+    return json;
+  }
+  
   Subject.call(this, json);
   
   if(json){
@@ -26,6 +32,18 @@ var Relationship = function(json){
 };
 
 Relationship.prototype = Object.create(Subject.prototype);
+
+Relationship._gedxClass = Relationship.prototype._gedxClass = 'GedcomX.Relationship';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Relationship.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the relationship type

--- a/src/ResourceReference.js
+++ b/src/ResourceReference.js
@@ -1,3 +1,5 @@
+var utils = require('./utils');
+
 /**
  * A generic reference to a resource.
  * 
@@ -11,9 +13,26 @@ var ResourceReference = function(json){
     return new ResourceReference(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(ResourceReference.isInstance(json)){
+    return json;
+  }
+  
   if(json){
     this.setResource(json.resource);
   }
+};
+
+ResourceReference._gedxClass = ResourceReference.prototype._gedxClass = 'GedcomX.ResourceReference';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+ResourceReference.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
 };
 
 /**

--- a/src/SourceCitation.js
+++ b/src/SourceCitation.js
@@ -1,4 +1,5 @@
-var ExtensibleData = require('./ExtensibleData');
+var ExtensibleData = require('./ExtensibleData'),
+    utils = require('./utils');
 
 /**
  * A source citation.
@@ -13,6 +14,11 @@ var SourceCitation = function(json){
     return new SourceCitation(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(SourceCitation.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -22,6 +28,18 @@ var SourceCitation = function(json){
 };
 
 SourceCitation.prototype = Object.create(ExtensibleData.prototype);
+
+SourceCitation._gedxClass = SourceCitation.prototype._gedxClass = 'GedcomX.SourceCitation';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+SourceCitation.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the lang

--- a/src/SourceDescription.js
+++ b/src/SourceDescription.js
@@ -6,7 +6,8 @@ var ExtensibleData = require('./ExtensibleData'),
     Note = require('./Note'),
     Attribution = require('./Attribution'),
     Coverage = require('./Coverage'),
-    Identifiers = require('./Identifiers');
+    Identifiers = require('./Identifiers'),
+    utils = require('./utils');
 
 /**
  * A description of a source.
@@ -19,6 +20,11 @@ var SourceDescription = function(json){
   // Protect against forgetting the new keyword when calling the constructor
   if(!(this instanceof SourceDescription)){
     return new SourceDescription(json);
+  }
+  
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(SourceDescription.isInstance(json)){
+    return json;
   }
   
   ExtensibleData.call(this, json);
@@ -46,6 +52,18 @@ var SourceDescription = function(json){
 };
 
 SourceDescription.prototype = Object.create(ExtensibleData.prototype);
+
+SourceDescription._gedxClass = SourceDescription.prototype._gedxClass = 'GedcomX.SourceDescription';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+SourceDescription.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the resource type

--- a/src/SourceReference.js
+++ b/src/SourceReference.js
@@ -1,5 +1,6 @@
 var ExtensibleData = require('./ExtensibleData'),
-    Attribution = require('./Attribution');
+    Attribution = require('./Attribution'),
+    utils = require('./utils');
 
 /**
  * A reference to a discription of a source.
@@ -14,6 +15,11 @@ var SourceReference = function(json){
     return new SourceReference(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(SourceReference.isInstance(json)){
+    return json;
+  }
+  
   ExtensibleData.call(this, json);
   
   if(json){
@@ -23,6 +29,18 @@ var SourceReference = function(json){
 };
 
 SourceReference.prototype = Object.create(ExtensibleData.prototype);
+
+SourceReference._gedxClass = SourceReference.prototype._gedxClass = 'GedcomX.SourceReference';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+SourceReference.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Get the description.

--- a/src/Subject.js
+++ b/src/Subject.js
@@ -1,7 +1,8 @@
 var Conclusion = require('./Conclusion'),
     Identifiers = require('./Identifiers'),
     EvidenceReference = require('./EvidenceReference'),
-    SourceReference = require('./SourceReference');
+    SourceReference = require('./SourceReference'),
+    utils = require('./utils');
 
 /**
  * An object identified in time and space by various conclusions.
@@ -16,6 +17,11 @@ var Subject = function(json){
     return new Subject(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(Subject.isInstance(json)){
+    return json;
+  }
+  
   Conclusion.call(this, json);
   
   if(json){
@@ -27,6 +33,18 @@ var Subject = function(json){
 };
 
 Subject.prototype = Object.create(Conclusion.prototype);
+
+Subject._gedxClass = Subject.prototype._gedxClass = 'GedcomX.Subject';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+Subject.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
+};
 
 /**
  * Is this an extracted conclusion?

--- a/src/TextValue.js
+++ b/src/TextValue.js
@@ -1,3 +1,5 @@
+var utils = require('./utils');
+
 /**
  * A text value in a specific language.
  * 
@@ -11,10 +13,27 @@ var TextValue = function(json){
     return new TextValue(json);
   }
   
+  // If the given object is already an instance then just return it. DON'T copy it.
+  if(TextValue.isInstance(json)){
+    return json;
+  }
+  
   if(json){
     this.setLang(json.lang);
     this.setValue(json.value);
   }
+};
+
+TextValue._gedxClass = TextValue.prototype._gedxClass = 'GedcomX.TextValue';
+
+/**
+ * Check whether the given object is an instance of this class.
+ * 
+ * @param {Object} obj
+ * @returns {Boolean}
+ */
+TextValue.isInstance = function(obj){
+  return utils.isInstance(obj, this._gedxClass);
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,23 @@
+module.exports = {
+  
+  /**
+   * Check whether the given object is an instance of the specified class.
+   * The necessity for this is discussed in PR #13: https://github.com/rootsdev/gedcomx-js/pull/13
+   * 
+   * We put this functionality in a method to be DRY, even though it's short.
+   * This could easily change in the future for correction and performance.
+   * 
+   * It could be handy to expose this on GedcomX somewhere so that users of the
+   * library can use it too. But then we would need to add a way for them to
+   * easily get the _gedxClass property without being tied to that private
+   * property name. In other words, a static method such as Person.getClass()
+   * 
+   * @param {Object} obj
+   * @param {String} className
+   * @returns {Boolean}
+   */
+  isInstance: function(obj, className){
+    return obj && Object.getPrototypeOf(obj) !== Object.prototype && obj._gedxClass === className;
+  }
+  
+};

--- a/test/Address.js
+++ b/test/Address.js
@@ -78,4 +78,10 @@ describe('Address', function(){
     assert.deepEqual(address.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Address();
+    var obj2 = GedcomX.Address(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Agent.js
+++ b/test/Agent.js
@@ -209,4 +209,10 @@ describe('Agent', function(){
     assert.deepEqual(agent.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Agent();
+    var obj2 = GedcomX.Agent(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Attribution.js
+++ b/test/Attribution.js
@@ -67,4 +67,10 @@ describe('Attribution', function(){
     assert.deepEqual(attr.toJSON(), attrData, 'toJSON export does not equal original data.');
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Attribution();
+    var obj2 = GedcomX.Attribution(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Conclusion.js
+++ b/test/Conclusion.js
@@ -121,4 +121,10 @@ describe('Conclusion', function(){
     assert.deepEqual(conclusion.toJSON(), conclusionData);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Conclusion();
+    var obj2 = GedcomX.Conclusion(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Coverage.js
+++ b/test/Coverage.js
@@ -54,4 +54,10 @@ describe('Coverage', function(){
     assert.deepEqual(coverage.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Coverage();
+    var obj2 = GedcomX.Coverage(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Date.js
+++ b/test/Date.js
@@ -40,4 +40,10 @@ describe('Date', function(){
     assert.deepEqual(date.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Date();
+    var obj2 = GedcomX.Date(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Document.js
+++ b/test/Document.js
@@ -69,4 +69,10 @@ describe('Document', function(){
     assert.deepEqual(doc.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Document();
+    var obj2 = GedcomX.Document(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Event.js
+++ b/test/Event.js
@@ -97,4 +97,10 @@ describe('Event', function(){
     assert.deepEqual(event.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Event();
+    var obj2 = GedcomX.Event(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/EventRole.js
+++ b/test/EventRole.js
@@ -55,4 +55,10 @@ describe('EventRole', function(){
     assert.deepEqual(role.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.EventRole();
+    var obj2 = GedcomX.EventRole(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/EvidenceReference.js
+++ b/test/EvidenceReference.js
@@ -42,4 +42,10 @@ describe('EvidenceReference', function(){
     assert.deepEqual(er.toJSON(), erData);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.EvidenceReference();
+    var obj2 = GedcomX.EvidenceReference(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/ExtensibleData.js
+++ b/test/ExtensibleData.js
@@ -27,4 +27,10 @@ describe('ExtensibleData', function(){
     assert.deepEqual(ed.toJSON(), {id:'newId'}, 'JSON export is incorrect');
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.ExtensibleData();
+    var obj2 = GedcomX.ExtensibleData(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Fact.js
+++ b/test/Fact.js
@@ -105,4 +105,10 @@ describe('Fact', function(){
     assert.deepEqual(fact.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Fact();
+    var obj2 = GedcomX.Fact(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/GedcomX.js
+++ b/test/GedcomX.js
@@ -577,15 +577,10 @@ describe('GedcomX', function(){
     assert.jsonSchema(gedx.toJSON(), GedcomXSchema);
   });
   
-  it('adding Person does not copy', function(){
-    var gedx = GedcomX();
-    var person = GedcomX.Person({
-      id: 'first'
-    });
-    gedx.addPerson(person);
-    person.setId('second');
-    assert.strictEqual(gedx.getPersons()[0], person, 'the added instance is not the same as the original instance');
-    assert.deepEqual(gedx.getPersons()[0].toJSON(), person.toJSON(), 'serialization of the added person does not match the original person');
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX();
+    var obj2 = GedcomX(obj1);
+    assert.strictEqual(obj1, obj2);
   });
   
 });

--- a/test/GedcomX.js
+++ b/test/GedcomX.js
@@ -577,6 +577,17 @@ describe('GedcomX', function(){
     assert.jsonSchema(gedx.toJSON(), GedcomXSchema);
   });
   
+  it('adding Person does not copy', function(){
+    var gedx = GedcomX();
+    var person = GedcomX.Person({
+      id: 'first'
+    });
+    gedx.addPerson(person);
+    person.setId('second');
+    assert.strictEqual(gedx.getPersons()[0], person, 'the added instance is not the same as the original instance');
+    assert.deepEqual(gedx.getPersons()[0].toJSON(), person.toJSON(), 'serialization of the added person does not match the original person');
+  });
+  
 });
 
 function tests(gedx){

--- a/test/Gender.js
+++ b/test/Gender.js
@@ -51,4 +51,10 @@ describe('Gender', function(){
     assert.deepEqual(gender.toJSON(), genderData);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Gender();
+    var obj2 = GedcomX.Gender(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Name.js
+++ b/test/Name.js
@@ -125,4 +125,10 @@ describe('Name', function(){
     assert.deepEqual(name.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Name();
+    var obj2 = GedcomX.Name(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/NameForm.js
+++ b/test/NameForm.js
@@ -98,4 +98,10 @@ describe('NameForm', function(){
     assert.deepEqual(nameForm.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.NameForm();
+    var obj2 = GedcomX.NameForm(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/NamePart.js
+++ b/test/NamePart.js
@@ -73,4 +73,10 @@ describe('NamePart', function(){
     assert.deepEqual(part.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.NamePart();
+    var obj2 = GedcomX.NamePart(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Note.js
+++ b/test/Note.js
@@ -78,4 +78,10 @@ describe('Note', function(){
     assert.deepEqual(note.toJSON(), noteData);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Note();
+    var obj2 = GedcomX.Note(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/OnlineAccount.js
+++ b/test/OnlineAccount.js
@@ -48,4 +48,10 @@ describe('OnlineAccount', function(){
     assert.deepEqual(account.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.OnlineAccount();
+    var obj2 = GedcomX.OnlineAccount(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Person.js
+++ b/test/Person.js
@@ -138,4 +138,10 @@ describe('Person', function(){
     assert.deepEqual(person.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Person();
+    var obj2 = GedcomX.Person(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/PlaceDescription.js
+++ b/test/PlaceDescription.js
@@ -121,4 +121,10 @@ describe('PlaceDescription', function(){
     assert.deepEqual(place.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.PlaceDescription();
+    var obj2 = GedcomX.PlaceDescription(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/PlaceReference.js
+++ b/test/PlaceReference.js
@@ -40,4 +40,10 @@ describe('PlaceReference', function(){
     assert.deepEqual(ref.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.PlaceReference();
+    var obj2 = GedcomX.PlaceReference(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Qualifier.js
+++ b/test/Qualifier.js
@@ -35,4 +35,10 @@ describe('Qualifier', function(){
     assert.deepEqual(ref.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Qualifier();
+    var obj2 = GedcomX.Qualifier(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Relationship.js
+++ b/test/Relationship.js
@@ -85,4 +85,10 @@ describe('Relationship', function(){
     assert.deepEqual(relationship.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Relationship();
+    var obj2 = GedcomX.Relationship(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/ResourceReference.js
+++ b/test/ResourceReference.js
@@ -30,4 +30,10 @@ describe('ResourceReference', function(){
     assert.deepEqual(rr.toJSON(), {});
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.ResourceReference();
+    var obj2 = GedcomX.ResourceReference(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/SourceCitation.js
+++ b/test/SourceCitation.js
@@ -33,4 +33,10 @@ describe('SourceCitation', function(){
     assert.deepEqual(citation.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.SourceCitation();
+    var obj2 = GedcomX.SourceCitation(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/SourceDescription.js
+++ b/test/SourceDescription.js
@@ -280,4 +280,10 @@ describe('SourceDescription', function(){
     assert.deepEqual(description.toJSON(), fullJSON);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.SourceDescription();
+    var obj2 = GedcomX.SourceDescription(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/SourceReference.js
+++ b/test/SourceReference.js
@@ -58,4 +58,10 @@ describe('SourceReference', function(){
     assert.deepEqual(ref.toJSON(), refData);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.SourceReference();
+    var obj2 = GedcomX.SourceReference(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/Subject.js
+++ b/test/Subject.js
@@ -129,4 +129,10 @@ describe('Subject', function(){
     assert.deepEqual(subjectData, subject.toJSON());
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.Subject();
+    var obj2 = GedcomX.Subject(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });

--- a/test/TextValue.js
+++ b/test/TextValue.js
@@ -35,4 +35,10 @@ describe('TextValue', function(){
     assert.deepEqual(value.toJSON(), data);
   });
   
+  it('constructor does not copy instances', function(){
+    var obj1 = GedcomX.TextValue();
+    var obj2 = GedcomX.TextValue(obj1);
+    assert.strictEqual(obj1, obj2);
+  });
+  
 });


### PR DESCRIPTION
See the failing test I added. Basically, if we add an object that was created via a constructor, then it's copied and re-created while being added. So if you later modify that data via a reference you maintained then the changes are not properly reflected in the containing model.

``` js
var gedx = GedcomX();
var person = GedcomX.Person();
gedx.addPerson(person);

// The following line will evaluate to false
gedx.getPersons()[0] === person
```

This is a **BIG** bug.
